### PR TITLE
Fix/ajuste botao desativar

### DIFF
--- a/front/src/components/admin/Layout/AdminLayout.css
+++ b/front/src/components/admin/Layout/AdminLayout.css
@@ -1,6 +1,5 @@
 @import url("https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css");
 
-
 .mainAdmin {
   background: var(--gradiente-fundo);
   display: flex;
@@ -15,14 +14,15 @@
 }
 
 .fundo-content-admin {
-  height: 100vh;
+  min-height: 100vh;
   width: 100vw;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: flex-start; 
+  justify-content: flex-start;
   box-sizing: border-box;
   padding: 2rem;
+  padding-bottom: 5rem;
 }
 
 /* Cabeçalho */
@@ -59,12 +59,12 @@
   margin-left: 2%;
 }
 
-.sobre-nav-link i{
+.sobre-nav-link i {
   font-size: 1.2rem;
   margin-right: 3px;
 }
 
-.sobre-nav-link{
+.sobre-nav-link {
   font-size: 0.93rem;
   font-weight: 700;
   margin-top: 1.5rem;
@@ -74,12 +74,14 @@ footer {
   bottom: 0;
   left: 0;
   width: 100%;
-  height: 3.5rem; /* altura do rodapé, responsiva via rem */
+  height: 3.5rem; 
   background-color: #004990;
   display: flex;
   justify-content: flex-end;
   align-items: center;
   z-index: 10;
+  margin-top: auto; 
+  position:relative;
 }
 
 footer img {

--- a/front/src/components/admin/UsuarioDetalhes/UsuarioDetalhes.css
+++ b/front/src/components/admin/UsuarioDetalhes/UsuarioDetalhes.css
@@ -41,10 +41,19 @@
 /* Botões de Ação */
 .actions-row {
   display: flex;
+  flex-direction: row;
+  gap: 1rem;
+  align-items: center;
   justify-content: flex-start;
-  margin-top: 30px;
-  gap: 15px;
-  flex-wrap: wrap;
+  margin-top: 1.5rem;
+  width: 100%;
+}
+
+.actions-row .btn-primary {
+  display: inline-flex !important; /* Garante visibilidade em desktop */
+  align-items: center;
+  justify-content: center;
+  visibility: visible !important;
 }
 
 .btn-action {


### PR DESCRIPTION
# 🚀 Pull Request
--------------------------------------------------------------------------------
## 📝 Título
Fix/ajuste botao desativar

##Descrição
Em telas de alta resolução ou visualização desktop, o footer cobria visualmente a seção .actions-row devido à restrição de altura fixa no container principal e à falta de espaçamento inferior (padding-bottom), impedindo a interação do usuário com os botões

##Solução

- Alterada a propriedade de altura da classe .fundo-content-admin de height: 100vh para min-height: 100vh no layout administrativo.
- Adicionado padding-bottom: 5rem no container do conteúdo para garantir uma margem de segurança e evitar que qualquer elemento seja coberto pelo footer.
- Ajustado o fluxo posicional do footer para respeitar o conteúdo da página.

## 🧪 Como Foi Testado?
[X ] Testes unitários
[ ] Testes de integração
[ ] Testes manuais
[ ] Não aplicável

## 📌 Notas Adicionais (opcional)

## 👥 Revisores
- @MaduGoncalves 


Close # #109